### PR TITLE
Fix bug causing video to play if it is stopped/paused/unloaded in finished state

### DIFF
--- a/flowplayer.dashjs.js
+++ b/flowplayer.dashjs.js
@@ -135,7 +135,7 @@
                             player.trigger('finish', [player]);
 
                             bean.one(videoTag, "seeked." + engineName, function () {
-                                if (!videoTag.currentTime) {
+                                if (!~videoTag.currentTime) {
                                     videoTag.play();
                                 }
                             });


### PR DESCRIPTION
If I let a DASH video to get into the "finished" state and then use the flowplayer API to unload()/pause()/stop() (I tried those), the player starts to play the video from the beginning.

The execution always seemed to somehow go to line 139 where videoTag is asked to play(). videoTag.currentTime seemed to return 0, which is a falsy value. I'm not sure if this is intended, so I added ~ in front of it to make currentTime 0 truthy. This fixed the bug.

My setup:
Flowplayer 6.0.5
Chrome 48
Ubuntu 14.04
Tried with various MP4 videos.

I also tried if I can reproduce this on your DASH demo page: http://demos.flowplayer.org/api/dash.html
but there was a bug that it provided HLS video instead of DASH (someone already confirmed this at Flowplayer forum).
