### PR TITLE
Build with webpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,15 @@ DASHJSMOD=node_modules/dashjs
 
 GIT_ID=${shell git rev-parse --short HEAD }
 
-default:
-	@ mkdir -p $(DIST)
-	@ sed -e 's/\$$GIT_ID\$$/$(GIT_ID)/' -e '/"use strict";/d' flowplayer.dashjs.js | \
-		npm run minify > $(JS).min.js
-	@ cat $(DASHJSMOD)/dist/dash.mediaplayer.min.js >> $(JS).min.js
+webpack:
+	@ npm run build
 
 v5:
 	@ mkdir -p $(DIST)
-	@ sed -e 's/\$$GIT_ID\$$/$(GIT_ID)/' -e '/"use strict";/d' flowplayer.dashjs-v5.js | \
-		npm run minify > $(JS)-v5.min.js
+	@ sed -ne 's/\$$GIT_ID\$$/$(GIT_ID)/; /^\/\*!/,/^\*\// p' flowplayer.dashjs-v5.js > $(JS)-v5.min.js
 	@ cat dash.all.js >> $(JS)-v5.min.js
+	@ echo '' >> $(JS)-v5.min.js
+	@ npm run -s mini5 >> $(JS)-v5.min.js
 
 debug:
 	@ mkdir -p $(DIST)
@@ -25,7 +23,7 @@ debug:
 	@ sed -e 's/\$$GIT_ID\$$/$(GIT_ID)/' flowplayer.dashjs.js > $(JS).js
 	@ sed -e 's/\$$GIT_ID\$$/$(GIT_ID)/' flowplayer.dashjs-v5.js > $(JS)-v5.js
 
-all: default v5
+all: webpack v5
 
 dist: clean all debug
 	@ cp LICENSE.md $(DIST)/
@@ -40,4 +38,4 @@ lint:
 	@ npm run -s lint
 
 deps:
-	@ rm -rf $(DASHJSMOD) && npm install && npm run prepare
+	@ npm install

--- a/flowplayer.dashjs.js
+++ b/flowplayer.dashjs.js
@@ -21,7 +21,7 @@
 
 */
 
-(function () {
+(function (flowplayer, dashjs) {
     "use strict";
     var engineName = "dash",
         mse = window.MediaSource,
@@ -272,4 +272,6 @@
 
     }
 
-}());
+}.apply(null, (typeof module === 'object' && module.exports)
+    ? [require('flowplayer'), require('dashjs')]
+    : [window.flowplayer, window.dashjs]));

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "flowplayer.dashjs.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "jslint --edition=latest --devel flowplayer.dashjs.js",
-    "minify": "uglifyjs -m -c --comments='/Flowplayer Oy/' -o /dev/stdout -",
-    "prepare": "cd node_modules/dashjs; npm install; grunt dist; cd -"
+    "lint": "jslint --edition=latest --devel flowplayer.hlsjs.js",
+    "build": "webpack",
+    "mini5": "uglifyjs flowplayer.dashjs-v5.js -m -c"
   },
   "repository": {
     "type": "git",
@@ -20,14 +20,18 @@
   },
   "homepage": "https://github.com/flowplayer/flowplayer-mpegdash",
   "dependencies": {
-    "dashjs": "git://github.com/Dash-Industry-Forum/dash.js#dca1067bba2a95b93c7a38f8deb04aedbe2f1217"
+    "dashjs": "2.0.0"
   },
   "peerDependencies": {
     "flowplayer": "^6.0.3"
   },
   "devDependencies": {
+    "babel-core": "^6.5.1",
+    "babel-loader": "^6.2.2",
+    "babel-preset-es2015": "^6.5.0",
     "jslint": "^0.9.5",
-    "uglifyjs": "^2.4.10"
+    "uglifyjs": "^2.4.10",
+    "webpack": "^1.12.13"
   },
   "jshintConfig": {
     "undef": true


### PR DESCRIPTION
Tested with:

- node v5.6.0 / npm v3.6.0
- node v5.4.1 / npm v3.3.12
- node v4.3.1 / npm v2.14.12

See: https://github.com/flowplayer/flowplayer-hlsjs/issues/23

Result is bigger (344k vs 312k) than with concatenation of
dash.mediaplayer.min.js release; probably because some 'reduced version'
of dashjs.all.min.js (dash.mediaplayer.min.js + dash.protection.min.js?)
is compiled instead of just dash.mediaplayer.min.js

require('dashjs').MediaPlayer builds, but throws errors when used.

Maybe distribute dash.all.debug.js for debugging.